### PR TITLE
Fix task lookup in fetchTaskResult to use task_id instead of primary key

### DIFF
--- a/backend/app/Services/DataForSeoResultService.php
+++ b/backend/app/Services/DataForSeoResultService.php
@@ -103,6 +103,8 @@ class DataForSeoResultService
 
         $json = $response->json();
 
+        $task = DataForSeoTask::where('task_id', $taskId)->with('keyword.project')->first();
+
         $this->log('info', 'Polling DataForSEO task result', [
             'task_id' => $taskId,
             'keyword' => $task->keyword->keyword ?? null,


### PR DESCRIPTION
This PR addresses a bug in the DataForSeoResultService::fetchTaskResult() method where the system attempted to retrieve a DataForSeoTask model using find($taskId). This caused issues because task_id refers to the external API Task ID (UUID) rather than the model’s primary key.