### PR TITLE
fix(telescope): bypass CSRF protection for Telescope routes

### DIFF
--- a/backend/app/Http/Middleware/VerifyCsrfToken.php
+++ b/backend/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+
+class VerifyCsrfToken extends Middleware {
+
+    protected $except = [
+        'telescope/*',
+        'telescope-api/*',
+    ];
+
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\VerifyCsrfToken;
 use App\Providers\TelescopeServiceProvider;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -16,6 +17,9 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->group('api', [
             EnsureFrontendRequestsAreStateful::class,
+        ]);
+        $middleware->web(append: [
+            VerifyCsrfToken::class,
         ]);
     })
     ->withProviders([


### PR DESCRIPTION
- Updated bootstrap/app.php to exclude `telescope/*` and `telescope-api/*` from CSRF verification
- Resolves 500 errors caused by missing/invalid X-XSRF-TOKEN in Telescope XHR requests
- Allows Telescope UI to function in production without authentication or CSRF token