### PR TITLE
refactor(jobs): simplify ProcessSingleKeywordJob to only submit keywo…

### DIFF
--- a/backend/app/Jobs/ProcessSingleKeywordJob.php
+++ b/backend/app/Jobs/ProcessSingleKeywordJob.php
@@ -42,17 +42,6 @@ class ProcessSingleKeywordJob implements ShouldQueue
 
         $submissionService->submitToDataForSeo($payload, $keyword, $keyword->project, $credentials);
 
-        $taskData = $seoService->fetchResults($keyword);
-
-        if (!$taskData) {
-            Log::warning("⚠️ No task result yet — will retry for Keyword ID {$keyword->id}");
-            self::dispatch($keyword)->delay(now()->addSeconds(20));
-            return;
-        }
-
-        $seoService->storeResults($keyword, $taskData);
-        $keyword->update(['last_submitted_at' => now()]);
-
         Log::info("✅ Done for Keyword ID {$keyword->id}");
     }
 }


### PR DESCRIPTION
…rd task

- Removed immediate fetch/poll logic from ProcessSingleKeywordJob
- Now the job is responsible only for building payload and submitting keyword to DataForSEO
- Polling will be handled separately by PollDataForSeoTaskJob via DataForSeoTaskObserver
- Prevents duplicate jobs and ensures cleaner separation of responsibilities