### PR TITLE
feat(projects): add success toast for project creation and minor cleanup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,6 @@ import ProjectShowPage from './pages/ProjectShowPage';
 import KeywordShowPage from './pages/KeywordShowPage';
 import UserRegisterPage from './pages/UserRegisterPage';
 import UserLoginPage from './pages/UserLoginPage';
-import KeywordGroupPage from './components/Project/KeywordGroups.tsx';
 import ProjectsArchivedPage from "./pages/ProjectsArchivedPage";
 import { useAuth } from './context/AuthContext';
 import AppLayout from "./layouts/AppLayout.tsx";
@@ -44,7 +43,6 @@ export default function App() {
                         <Route path="/projects/archived" element={<ProjectsArchivedPage />} />
                         <Route path="/projects/:id" element={<ProjectShowPage />} />
                         <Route path="/keywords/:id" element={<KeywordShowPage />} />
-                        <Route path="/keyword-groups/" element={<KeywordGroupPage />} />
                         <Route path="/register" element={<UserRegisterPage />} />
                         {/* Already authenticated: redirect away from /login */}
                         <Route path="/login" element={<Navigate to="/dashboard" replace />} />

--- a/frontend/src/components/Dialogs/ProjectDialog/CreateProjectDialog.tsx
+++ b/frontend/src/components/Dialogs/ProjectDialog/CreateProjectDialog.tsx
@@ -15,6 +15,7 @@ interface Props {
 export default function CreateProjectDialog({ isOpen, onClose, onCreate }: Props) {
 
     const [data, setData] = useState<Project>({
+        keyword_groups: [],
         keywords: [],
         id: Date.now(),
         name: '',
@@ -23,7 +24,7 @@ export default function CreateProjectDialog({ isOpen, onClose, onCreate }: Props
         location_code: 0,
         created_at: '',
         location_name: '',
-        deleted_at: '',
+        deleted_at: ''
     });
     const [selectedCountry, setSelectedCountry] = useState<CountryOption | null>(null);
     const [loading, setLoading] = useState(false);

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -39,6 +39,7 @@ export default function ProjectsPage() {
         try {
             const createdProject = await projectService.create(data);
             setRealProjects((prev) => [...prev, createdProject]);
+            toast.success("Project created successfully.");
         } catch (error: any) {
             toast.error(error.response.data.message || "Failed to create project.");
         }


### PR DESCRIPTION
- Display success toast upon project creation for better user feedback.
- Removed unused `KeywordGroupPage` route and related import.
- Initialized `keyword_groups` in the default project state for `CreateProjectDialog`.