### PR TITLE
fix(schedule): remove duplicate keyword scheduler and skip volume ref…

### DIFF
--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -5,13 +5,11 @@ namespace App\Console;
 use App\Jobs\CheckBacklinksJob;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
-use App\Jobs\ProcessDailyKeywordRanksJob;
 
 class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule): void
     {
-        $schedule->job(new ProcessDailyKeywordRanksJob)->everyMinute();
         $schedule->job(new CheckBacklinksJob)->weeklyOn(1, '00:00');
     }
 

--- a/backend/app/Jobs/ProcessDailyKeywordRanksJob.php
+++ b/backend/app/Jobs/ProcessDailyKeywordRanksJob.php
@@ -35,7 +35,7 @@ class ProcessDailyKeywordRanksJob implements ShouldQueue
                         continue;
                     }
 
-                    dispatch(new ProcessSingleKeywordJob($keyword));
+                    dispatch(new ProcessSingleKeywordJob($keyword, false));
                     $processed++;
 
                     Log::info("🚀 Queued submission job for Keyword ID {$keyword->id} ({$keyword->keyword})");

--- a/backend/app/Jobs/ProcessSingleKeywordJob.php
+++ b/backend/app/Jobs/ProcessSingleKeywordJob.php
@@ -18,10 +18,12 @@ class ProcessSingleKeywordJob implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     protected Keyword $keyword;
+    protected bool $shouldRefreshSearchVolume;
 
-    public function __construct(Keyword $keyword)
+    public function __construct(Keyword $keyword, bool $shouldRefreshSearchVolume = true)
     {
         $this->keyword = $keyword;
+        $this->shouldRefreshSearchVolume = $shouldRefreshSearchVolume;
     }
 
     public function handle(KeywordSubmissionService $submissionService, SearchValueService $searchValueService): void {
@@ -39,8 +41,10 @@ class ProcessSingleKeywordJob implements ShouldQueue
 
         $submissionService->submitToDataForSeo($payload, $keyword, $keyword->project, $credentials);
 
-        // Also submit task for search volume
-        $searchValueService->createTaskForKeyword($keyword);
+        if ($this->shouldRefreshSearchVolume) {
+            // Also submit task for search volume
+            $searchValueService->createTaskForKeyword($keyword);
+        }
 
         Log::info("✅ Done for Keyword ID {$keyword->id}");
     }


### PR DESCRIPTION
Remove the stale every-minute keyword scheduler from Console Kernel.

Scheduled keyword refresh now updates only SERP ranks on the twice-monthly schedule and no longer creates search volume tasks.