### PR TITLE
Dev dmytro

### DIFF
--- a/backend/app/Http/Controllers/LinkController.php
+++ b/backend/app/Http/Controllers/LinkController.php
@@ -1,65 +1,59 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Enums\LinkType;
 use App\Models\LinkTarget;
 use App\Models\Project;
 use App\Services\LinkService;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
-
+use Illuminate\Http\Request;
 
 class LinkController extends Controller
 {
-    protected LinkService $linkService;
+    public function __construct(
+        protected LinkService $linkService,
+    ) {}
 
-    public function __construct(LinkService $service)
+    public function index(Request $request, string $projectId, string $type): JsonResponse
     {
-        $this->linkService = $service;
-    }
-
-
-    public function index(Request $request,  $projectId, string $type): JsonResponse {
-
-        $project = Project::findOrFail($projectId);
-        $enum = LinkType::tryFrom($type);
-        $dbType = match($enum) {
+        $project = Project::query()->findOrFail($projectId);
+        $dbType = match (LinkType::from($type)) {
             LinkType::Backlinks => 'backlink',
             LinkType::Citations => 'citation',
         };
 
-        $data = $this->linkService->getLinksByType($project, $dbType);
-
-        return response()->json($data);
+        return response()->json($this->linkService->getLinksByType($project, $dbType));
     }
 
-    public function store(Request $request, $projectId): JsonResponse
+    public function store(Request $request, string $projectId): JsonResponse
     {
         $request->validate([
-            'urls'   => 'required|array|min:1',
+            'urls' => 'required|array|min:1',
             'urls.*' => 'required|url|max:255|distinct',
-            'type'   => 'required|string|in:backlinks,citations',
+            'type' => 'required|string|in:backlinks,citations',
         ]);
 
-        $project = Project::findOrFail($projectId);
+        $project = Project::query()->findOrFail($projectId);
         $result = $this->linkService->addUrls($project, $request->urls, $request->type);
 
         return response()->json([
-            'message' => 'Processing complete.',
-            'data'    => [
-                'added_count'   => count($result['added']),
+            'message' => 'URLs added and queued for checking.',
+            'data' => [
+                'added_count' => count($result['added']),
                 'skipped_count' => count($result['skipped']),
-                'added_urls'    => $result['added'],
-                'skipped_urls'  => $result['skipped'],
-            ]
+                'added_urls' => $result['added'],
+                'skipped_urls' => $result['skipped'],
+            ],
         ], 201);
     }
 
-    public function destroy(string $projectId , string $id):JsonResponse {
-
+    public function destroy(string $projectId, string $id): JsonResponse
+    {
         try {
-            $backlink = LinkTarget::findOrFail($id);
+            $backlink = LinkTarget::query()->findOrFail($id);
 
             $this->linkService->removeBacklink($backlink);
 
@@ -67,29 +61,27 @@ class LinkController extends Controller
                 'status' => 'success',
                 'message' => 'Link has been deleted',
             ]);
-        }catch (\Exception $e) {
+        } catch (\Throwable $exception) {
             return response()->json([
-                    'status' => 'error',
-                    'message' => $e->getMessage()]
-                , 500);
+                'status' => 'error',
+                'message' => $exception->getMessage(),
+            ], 500);
         }
-
     }
 
-    public function reCheckAllLinks (Request $request, $projectId): JsonResponse {
+    public function reCheckAllLinks(Request $request, string $projectId): JsonResponse
+    {
+        $project = Project::query()->findOrFail($projectId);
+        $projectLinks = $request->type === 'citations'
+            ? $project->citations()->get()
+            : $project->backlinks()->get();
 
-        $project = Project::findOrFail($projectId);
-        $project_links = $project->backlinks()->get();
-        if ($request->type === 'citations') {
-            $project_links = $project->citations()->get();
-        }
-
-        $project_links->each(function ($link) {
+        $projectLinks->each(function (LinkTarget $link): void {
             $this->linkService->checkBacklink($link);
         });
 
-        return response()->json(
-            ['message' => 'All links have been rechecked.']
-        );
+        return response()->json([
+            'message' => 'All links have been rechecked.',
+        ]);
     }
 }

--- a/backend/app/Jobs/ProcessLinkSubmissionChunkJob.php
+++ b/backend/app/Jobs/ProcessLinkSubmissionChunkJob.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\LinkTarget;
+use App\Services\LinkService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+class ProcessLinkSubmissionChunkJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public const int DEFAULT_CHUNK_SIZE = LinkService::SUBMISSION_BATCH_SIZE;
+
+    public int $timeout = 900;
+
+    /**
+     * @param  array<int>  $linkTargetIds
+     */
+    public function __construct(
+        public array $linkTargetIds,
+    ) {}
+
+    /**
+     * @param  array<int>  $linkTargetIds
+     */
+    public static function dispatchForLinkTargetIds(array $linkTargetIds): void
+    {
+        collect($linkTargetIds)
+            ->map(static fn (int $linkTargetId): int => $linkTargetId)
+            ->filter(static fn (int $linkTargetId): bool => $linkTargetId > 0)
+            ->values()
+            ->chunk(self::DEFAULT_CHUNK_SIZE)
+            ->each(function (Collection $chunk): void {
+                if (config('queue.default') === 'sync') {
+                    self::dispatchAfterResponse($chunk->all());
+
+                    return;
+                }
+
+                self::dispatch($chunk->all());
+            });
+    }
+
+    public function handle(LinkService $linkService): void
+    {
+        $targets = LinkTarget::query()
+            ->whereIn('id', $this->linkTargetIds)
+            ->get()
+            ->keyBy('id');
+
+        $targetsToProcess = new EloquentCollection;
+
+        foreach ($this->linkTargetIds as $linkTargetId) {
+            /** @var LinkTarget|null $target */
+            $target = $targets->get($linkTargetId);
+
+            if ($target === null) {
+                Log::warning('Skipped backlink submission because target is missing.', [
+                    'link_target_id' => $linkTargetId,
+                ]);
+
+                continue;
+            }
+
+            $targetsToProcess->push($target);
+        }
+
+        if ($targetsToProcess->isEmpty()) {
+            return;
+        }
+
+        Log::info('Processing backlink submission batch.', [
+            'target_count' => $targetsToProcess->count(),
+        ]);
+
+        $linkService->submitBacklinkBatch($targetsToProcess);
+
+        Log::info('Finished backlink submission batch.', [
+            'target_count' => $targetsToProcess->count(),
+        ]);
+    }
+}

--- a/backend/app/Services/LinkService.php
+++ b/backend/app/Services/LinkService.php
@@ -1,162 +1,275 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use App\Enums\LinkType;
-use App\Models\Project;
+use App\Jobs\ProcessLinkSubmissionChunkJob;
 use App\Models\LinkTarget;
 use App\Models\LinkTask;
-use Illuminate\Database\Eloquent\Collection;
+use App\Models\Project;
+use App\Services\DataForSeo\CredentialsService;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class LinkService
 {
+    public const int SUBMISSION_BATCH_SIZE = 100;
+
     /**
-     * Add unique URLs and create DFS tasks.
-     * Skips URLs that already exist for this project and type.
+     * Add unique URLs and queue DFS tasks in the background.
+     *
+     * @param  array<int, string>  $urls
+     * @return array{
+     *     added: array<int, array<string, mixed>>,
+     *     skipped: array<int, string>
+     * }
      */
     public function addUrls(Project $project, array $urls, string $type): array
     {
-        // 1. Resolve Type
-        $enum = LinkType::tryFrom($type);
-        // Fallback or throw error if invalid type (though validation catches this)
-        $dbType = match($enum) {
-            LinkType::Backlinks => 'backlink',
-            LinkType::Citations => 'citation',
-            default => 'backlink'
-        };
+        $dbType = $this->resolveDatabaseType(LinkType::from($type));
 
-        // 2. Normalize Input
-        $incomingUrls = collect($urls)->map(fn($u) => trim($u))->unique();
+        $incomingUrls = collect($urls)
+            ->map(static fn (string $url): string => trim($url))
+            ->filter(static fn (string $url): bool => $url !== '')
+            ->unique()
+            ->values();
 
-        // 3. Find Existing URLs in DB (for this project & type)
         $existingUrls = $project->link_urls()
             ->where('type', $dbType)
             ->whereIn('url', $incomingUrls)
             ->pluck('url')
-            ->toArray();
+            ->all();
 
-        // 4. Calculate New URLs (Diff)
-        $newUrls = $incomingUrls->diff($existingUrls);
+        $newUrls = $incomingUrls->diff($existingUrls)->values();
+        $addedTargets = new EloquentCollection;
 
-        $addedModels = [];
-
-        // 5. Create & Trigger Checks for NEW URLs only
         foreach ($newUrls as $url) {
-            /** @var LinkTarget $target */
-            $target = $project->link_urls()->create([
-                'url'  => $url,
+            $addedTargets->push($project->link_urls()->create([
+                'url' => $url,
                 'type' => $dbType,
-            ]);
-
-            // Trigger the external API check immediately
-            $this->checkBacklink($target);
-
-            $addedModels[] = $target;
+            ]));
         }
 
-        // 6. Return structured result
+        if ($addedTargets->isNotEmpty()) {
+            ProcessLinkSubmissionChunkJob::dispatchForLinkTargetIds($addedTargets->modelKeys());
+        }
+
         return [
-            'added'   => $addedModels,
-            'skipped' => $existingUrls, // List of URLs that were duplicates
+            'added' => $addedTargets
+                ->map(fn (LinkTarget $target): array => $this->transformLinkTarget($target, true))
+                ->all(),
+            'skipped' => array_values($existingUrls),
         ];
     }
 
     /**
-     * Universal shared function to get targets by type
+     * Universal shared function to get targets by type.
+     *
+     * @return Collection<int, array<string, mixed>>
      */
-    public function getLinksByType(Project $project, string $type): Collection|\Illuminate\Support\Collection {
-        // We filter by the 'type' column here
+    public function getLinksByType(Project $project, string $type): Collection
+    {
         $targets = $project->link_urls()
             ->where('type', $type)
-            ->with(['checks' => fn($q) => $q->orderBy('checked_at', 'desc')])
+            ->withExists([
+                'tasks as has_pending_task' => static fn ($query) => $query->whereNull('completed_at'),
+            ])
+            ->with([
+                'checks' => static fn ($query) => $query->orderByDesc('checked_at'),
+            ])
             ->orderBy('id')
             ->get();
 
-        return $targets->map(function ($t) {
-            $latest = $t->checks->first();
-            $isChecking = $t->tasks()->whereNull('completed_at')->exists();
-
-            return [
-                'id'            => $t->id,
-                'url'           => $t->url,
-                'type'          => $t->type, // Useful to see in the response
-                'is_checking'   => $isChecking,
-
-                'latest_result' => $latest ? [
-                    'http_code'   => $latest->http_code,
-                    'indexed'     => $latest->indexed,
-                    'checked_at'  => $latest->checked_at,
-                ] : (object)[],
-
-                'history'       => $t->checks->map(fn($h) => [
-                    'http_code'  => $h->http_code,
-                    'indexed'    => $h->indexed,
-                    'title'      => $h->title ?? null, // Added null check safety
-                    'checked_at' => $h->checked_at,
-                ]),
-            ];
-        });
+        return $targets->map(
+            fn (LinkTarget $target): array => $this->transformLinkTarget(
+                target: $target,
+                isChecking: (bool) $target->getAttribute('has_pending_task'),
+            ),
+        );
     }
 
     /**
-     * Return only Backlinks
+     * Return only Backlinks.
+     *
+     * @return Collection<int, array<string, mixed>>
      */
-    public function getBacklinkList(Project $project): Collection|\Illuminate\Support\Collection {
+    public function getBacklinkList(Project $project): Collection
+    {
         return $this->getLinksByType($project, 'backlink');
     }
 
     /**
-     * Return only Citations
+     * Return only Citations.
+     *
+     * @return Collection<int, array<string, mixed>>
      */
-    public function getCitationList(Project $project): Collection|\Illuminate\Support\Collection {
+    public function getCitationList(Project $project): Collection
+    {
         return $this->getLinksByType($project, 'citation');
     }
 
-    /**
-     * Trigger a check for a single backlink target
-     */
     public function checkBacklink(LinkTarget $target): void
     {
-        $username = config('services.dataforseo.username');
-        $password = config('services.dataforseo.password');
+        $this->submitBacklinkBatch(new EloquentCollection([$target]));
+    }
 
-        $payload = $this->buildPayload($target);
+    /**
+     * @param  EloquentCollection<int, LinkTarget>  $targets
+     * @return array{success: bool, message: string}
+     */
+    public function submitBacklinkBatch(EloquentCollection $targets): array
+    {
+        if ($targets->isEmpty()) {
+            return [
+                'success' => true,
+                'message' => 'No backlink targets to submit.',
+            ];
+        }
 
-        $response = Http::withBasicAuth($username, $password)
-            ->post("https://api.dataforseo.com/v3/serp/google/organic/task_post", $payload)
-            ->json();
-
-        $task = $response['tasks'][0] ?? null;
-
-        if ($task) {
-            LinkTask::create([
-                'backlink_target_id' => $target->id,
-                'task_id'            => $task['id'],
-                'status_code'        => $task['status_code'],
-                'status_message'     => $task['status_message'],
+        try {
+            $credentials = CredentialsService::get();
+        } catch (\Throwable $exception) {
+            Log::error('Failed to resolve DataForSEO credentials for backlink batch.', [
+                'error' => $exception->getMessage(),
+                'target_count' => $targets->count(),
             ]);
+
+            return [
+                'success' => false,
+                'message' => 'Missing DataForSEO credentials.',
+            ];
+        }
+
+        $payload = [];
+        $targetsByTag = [];
+
+        foreach ($targets as $target) {
+            $payload[] = $this->buildTaskPayload($target);
+            $targetsByTag[(string) $target->id] = $target;
+        }
+
+        try {
+            $response = Http::withBasicAuth($credentials['username'], $credentials['password'])
+                ->post('https://api.dataforseo.com/v3/serp/google/organic/task_post', $payload);
+
+            $json = $response->json();
+
+            Log::info('DataForSEO batch response after submitting backlinks', [
+                'target_count' => count($payload),
+                'data' => $json,
+            ]);
+
+            if (! $response->successful() || ! isset($json['tasks']) || ! is_array($json['tasks'])) {
+                Log::warning('Invalid backlink batch response from DataForSEO.', [
+                    'response' => $json,
+                ]);
+
+                return [
+                    'success' => false,
+                    'message' => 'Invalid batch response from DataForSEO.',
+                ];
+            }
+
+            foreach ($json['tasks'] as $task) {
+                $tag = (string) ($task['data']['tag'] ?? '');
+
+                if ($tag === '' || ! isset($targetsByTag[$tag])) {
+                    Log::warning('Skipped backlink batch task because tag mapping is missing.', [
+                        'task' => $task,
+                    ]);
+
+                    continue;
+                }
+
+                if (! isset($task['id'])) {
+                    Log::warning('Skipped backlink batch task because task id is missing.', [
+                        'task' => $task,
+                    ]);
+
+                    continue;
+                }
+
+                LinkTask::create([
+                    'backlink_target_id' => $targetsByTag[$tag]->id,
+                    'task_id' => $task['id'],
+                    'status_code' => $task['status_code'] ?? null,
+                    'status_message' => $task['status_message'] ?? null,
+                    'raw_response' => json_encode($task, JSON_THROW_ON_ERROR),
+                ]);
+            }
+
+            return [
+                'success' => true,
+                'message' => 'Backlink batch submitted successfully.',
+            ];
+        } catch (\Throwable $exception) {
+            Log::error('Failed to submit backlink batch to DataForSEO.', [
+                'error' => $exception->getMessage(),
+                'target_count' => count($payload),
+            ]);
+
+            return [
+                'success' => false,
+                'message' => 'Exception occurred during backlink submission.',
+            ];
         }
     }
 
-    /**
-     * Build DFS payload
-     */
-    protected function buildPayload(LinkTarget $target): array
+    public function removeBacklink(LinkTarget $target): void
     {
-        return [[
-                    "language_name" => "English",
-                    "location_name" => "Canada",
-                    "tag"           => $target->id,
-                    "keyword"       => "site:{$target->url}",
-                ]];
-    }
-
-    /**
-     * Remove a backlink target from the project
-     */
-    public function removeBacklink(LinkTarget $target): void {
         $target->delete();
     }
 
+    protected function buildTaskPayload(LinkTarget $target): array
+    {
+        return [
+            'language_name' => 'English',
+            'location_name' => 'Canada',
+            'tag' => (string) $target->id,
+            'keyword' => "site:{$target->url}",
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function transformLinkTarget(LinkTarget $target, bool $isChecking): array
+    {
+        $checks = $target->relationLoaded('checks')
+            ? $target->checks
+            : $target->checks()->orderByDesc('checked_at')->get();
+
+        $latest = $checks->first();
+
+        return [
+            'id' => $target->id,
+            'url' => $target->url,
+            'type' => $target->type,
+            'is_checking' => $isChecking,
+            'latest_result' => [
+                'http_code' => $latest?->http_code,
+                'indexed' => $latest?->indexed,
+                'title' => $latest?->title,
+                'checked_at' => $latest?->checked_at,
+            ],
+            'history' => $checks->map(static fn ($check): array => [
+                'http_code' => $check->http_code,
+                'indexed' => $check->indexed,
+                'title' => $check->title,
+                'checked_at' => $check->checked_at,
+            ])->values()->all(),
+        ];
+    }
+
+    protected function resolveDatabaseType(LinkType $type): string
+    {
+        return match ($type) {
+            LinkType::Backlinks => 'backlink',
+            LinkType::Citations => 'citation',
+        };
+    }
 }

--- a/backend/tests/Feature/LinkBulkSubmissionTest.php
+++ b/backend/tests/Feature/LinkBulkSubmissionTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Jobs\ProcessLinkSubmissionChunkJob;
+use App\Models\Project;
+use App\Models\User;
+use App\Services\LinkService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class LinkBulkSubmissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_bulk_link_addition_is_chunked_into_background_jobs(): void
+    {
+        Queue::fake();
+        Http::fake();
+        Config::set('queue.default', 'database');
+
+        $user = User::factory()->create();
+        $project = Project::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $urls = array_map(
+            static fn (int $index): string => "https://example{$index}.com",
+            range(1, 130),
+        );
+
+        $response = $this->postJson("/api/projects/{$project->id}/links", [
+            'urls' => $urls,
+            'type' => 'backlinks',
+        ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonPath('message', 'URLs added and queued for checking.')
+            ->assertJsonPath('data.added_count', 130)
+            ->assertJsonPath('data.skipped_count', 0)
+            ->assertJsonPath('data.added_urls.0.is_checking', true)
+            ->assertJsonPath('data.added_urls.0.latest_result.http_code', null);
+
+        Queue::assertPushed(ProcessLinkSubmissionChunkJob::class, 2);
+
+        $queuedLinkCount = 0;
+
+        Queue::assertPushed(ProcessLinkSubmissionChunkJob::class, function (ProcessLinkSubmissionChunkJob $job) use (&$queuedLinkCount): bool {
+            $queuedLinkCount += count($job->linkTargetIds);
+
+            return count($job->linkTargetIds) <= ProcessLinkSubmissionChunkJob::DEFAULT_CHUNK_SIZE;
+        });
+
+        $this->assertSame(130, $queuedLinkCount);
+        Http::assertNothingSent();
+    }
+
+    public function test_link_submission_chunk_job_submits_backlinks_in_one_batch_request(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $project = Project::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $firstTarget = $project->link_urls()->create([
+            'url' => 'https://alpha.example.com',
+            'type' => 'backlink',
+        ]);
+
+        $secondTarget = $project->link_urls()->create([
+            'url' => 'https://beta.example.com',
+            'type' => 'backlink',
+        ]);
+
+        Http::fake([
+            'https://api.dataforseo.com/v3/serp/google/organic/task_post' => Http::response([
+                'tasks' => [
+                    [
+                        'id' => 'task-alpha',
+                        'status_code' => 20100,
+                        'status_message' => 'Task Created.',
+                        'data' => [
+                            'tag' => (string) $firstTarget->id,
+                        ],
+                    ],
+                    [
+                        'id' => 'task-beta',
+                        'status_code' => 20100,
+                        'status_message' => 'Task Created.',
+                        'data' => [
+                            'tag' => (string) $secondTarget->id,
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $job = new ProcessLinkSubmissionChunkJob([$firstTarget->id, $secondTarget->id]);
+
+        $job->handle(app(LinkService::class));
+
+        Http::assertSentCount(1);
+        Http::assertSent(function (\Illuminate\Http\Client\Request $request) use ($firstTarget, $secondTarget): bool {
+            if ($request->url() !== 'https://api.dataforseo.com/v3/serp/google/organic/task_post') {
+                return false;
+            }
+
+            $payload = $request->data();
+
+            return count($payload) === 2
+                && $payload[0]['tag'] === (string) $firstTarget->id
+                && $payload[1]['tag'] === (string) $secondTarget->id;
+        });
+
+        $this->assertDatabaseCount('backlink_tasks', 2);
+        $this->assertDatabaseHas('backlink_tasks', [
+            'backlink_target_id' => $firstTarget->id,
+            'task_id' => 'task-alpha',
+        ]);
+        $this->assertDatabaseHas('backlink_tasks', [
+            'backlink_target_id' => $secondTarget->id,
+            'task_id' => 'task-beta',
+        ]);
+    }
+}

--- a/frontend/src/components/Dialogs/Notification/ErrorToast.tsx
+++ b/frontend/src/components/Dialogs/Notification/ErrorToast.tsx
@@ -1,0 +1,50 @@
+import toast, { type Toast } from 'react-hot-toast';
+import { Box, Button, Paper, Typography } from '@mui/material';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import React from "react";
+
+interface Props {
+    toastInstance: Toast;
+    message: string | React.ReactNode;
+}
+
+export default function ErrorToast({ toastInstance, message }: Props) {
+    return (
+        <Paper
+            elevation={6}
+            sx={{
+                maxWidth: 500,
+                width: '100%',
+                display: 'flex',
+                borderRadius: 2,
+                overflow: 'hidden',
+                border: '1px solid',
+                borderColor: 'error.light',
+                opacity: toastInstance.visible ? 1 : 0,
+                transition: 'opacity 0.3s ease',
+            }}
+        >
+            <Box sx={{ flex: 1, p: 2, display: 'flex', gap: 1.5, alignItems: 'flex-start' }}>
+                <ErrorOutlineIcon color="error" sx={{ mt: 0.3, flexShrink: 0 }} />
+                <Typography variant="body2" sx={{ color: 'text.primary', wordBreak: 'break-word' }}>
+                    {message}
+                </Typography>
+            </Box>
+            <Box sx={{ borderLeft: '1px solid', borderColor: 'divider', display: 'flex' }}>
+                <Button
+                    onClick={() => toast.dismiss(toastInstance.id)}
+                    sx={{
+                        borderRadius: 0,
+                        px: 2,
+                        color: 'error.main',
+                        fontWeight: 600,
+                        fontSize: '0.8rem',
+                        minWidth: 70,
+                    }}
+                >
+                    Close
+                </Button>
+            </Box>
+        </Paper>
+    );
+}

--- a/frontend/src/components/Tables/LinksTable/LinksTable.tsx
+++ b/frontend/src/components/Tables/LinksTable/LinksTable.tsx
@@ -18,6 +18,7 @@ interface Props {
     links: LinkItem[];
     loading: boolean;
     onRefresh?: () => void;
+    onAdded?: (items: LinkItem[]) => void;
     onDelete?: (id: number) => void;
     projectId: string;
     openHistory: (item: LinkItem) => void;
@@ -43,7 +44,7 @@ const SkippedUrlsList = ({ urls }: { urls: string[] }) => (
     </div>
 );
 
-export default function LinksTable({type, links, loading, projectId, openHistory, onRefresh, onDelete}: Props) {
+export default function LinksTable({type, links, loading, projectId, openHistory, onRefresh, onAdded, onDelete}: Props) {
     const [addingUrlDialog, setAddingUrlDialog] = useState(false);
     const link_type = type === 'backlinks' ? 'Backlinks' : 'Citations';
 
@@ -53,6 +54,7 @@ export default function LinksTable({type, links, loading, projectId, openHistory
         try {
             const response = await linkService.create(projectId, urls, type);
             toast.success(response.message);
+            onAdded?.(response.data.added_urls);
             if (response.data.skipped_urls.length > 0) {
                 toast.custom(
                     (toastInstance) => (
@@ -64,7 +66,6 @@ export default function LinksTable({type, links, loading, projectId, openHistory
                     { duration: Infinity },
                 );
             }
-            onRefresh?.();
         } catch (e) {
             console.error(e);
             toast.error("Failed to add URLs");
@@ -95,7 +96,7 @@ export default function LinksTable({type, links, loading, projectId, openHistory
                         sx={{display: 'flex', alignContent: 'center', alignItems: 'center', gap: '5px'}}
                         onClick={()=>{
                             linkService.reCheckAllLinks(projectId, type).then(
-                                (response: any) => {
+                                (response) => {
                                     toast.success(response.message || "Rechecking all links started.");
                                     onRefresh?.();
                                 },
@@ -118,13 +119,11 @@ export default function LinksTable({type, links, loading, projectId, openHistory
                     rowData={links}
                     columnDefs={columnDefs}
                     defaultColDef={defaultColDef}
-                    autoSizeStrategy={{
-                        type: 'fitCellContents'
-                    }}
+                    getRowId={({ data }) => String(data.id)}
                     context={{ openHistory, onDelete, projectId}}
                     pagination={true}
                     paginationPageSize={20}
-                    animateRows={true}
+                    animateRows={false}
                     groupDisplayType="groupRows"
                     rowGroupPanelShow="never"
                     loading={loading}

--- a/frontend/src/components/Tables/LinksTable/LinksTable.tsx
+++ b/frontend/src/components/Tables/LinksTable/LinksTable.tsx
@@ -9,6 +9,7 @@ import type { LinkItem } from "../../../services/linkService.ts";
 import linkService from "../../../services/linkService.ts";
 import toast from "react-hot-toast";
 import AddUrlDialog from "../../Dialogs/AddUrl/AddUrlDialog.tsx";
+import ErrorToast from "../../Dialogs/Notification/ErrorToast.tsx";
 import RotateLeftIcon from '@mui/icons-material/RotateLeft';
 import ExportLinksButton from "./ExportLinksButton.tsx";
 
@@ -22,16 +23,46 @@ interface Props {
     openHistory: (item: LinkItem) => void;
 }
 
+const SkippedUrlsList = ({ urls }: { urls: string[] }) => (
+    <div style={{ textAlign: 'left' }}>
+        <div style={{ fontWeight: 'bold', marginBottom: '8px' }}>
+            Some URLs were skipped (already exist in table):
+        </div>
+        <ul style={{
+            margin: 0,
+            paddingLeft: '20px',
+            fontSize: '12px',
+            wordBreak: 'break-all'
+        }}>
+            {urls.map((url, index) => (
+                <li key={index} style={{ marginBottom: '4px' }}>
+                    {url}
+                </li>
+            ))}
+        </ul>
+    </div>
+);
+
 export default function LinksTable({type, links, loading, projectId, openHistory, onRefresh, onDelete}: Props) {
     const [addingUrlDialog, setAddingUrlDialog] = useState(false);
     const link_type = type === 'backlinks' ? 'Backlinks' : 'Citations';
 
     const handleAddUrl = async (urls: string[]) => {
+        toast.success("URLs sent for processing. Please wait for the results.");
+        setAddingUrlDialog(false);
         try {
             const response = await linkService.create(projectId, urls, type);
             toast.success(response.message);
-            if(response.data.skipped_urls.length > 0) {
-                toast.error(`Some URLs were skipped (It's already exist in table): ${response.data.skipped_urls.join(', ')}`);
+            if (response.data.skipped_urls.length > 0) {
+                toast.custom(
+                    (toastInstance) => (
+                        <ErrorToast
+                            toastInstance={toastInstance}
+                            message={<SkippedUrlsList urls={response.data.skipped_urls} />}
+                        />
+                    ),
+                    { duration: Infinity },
+                );
             }
             onRefresh?.();
         } catch (e) {

--- a/frontend/src/pages/project/ProjectLinkPage.tsx
+++ b/frontend/src/pages/project/ProjectLinkPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import linkService, { type LinkItem } from "../../services/linkService.ts";
 import {
     Drawer,
@@ -35,25 +35,43 @@ export default function ProjectLinkPage() {
     const [projectName, setProjectName] = useState<string>("");
     const [loading, setLoading] = useState(true);
     const [historyData, setHistoryData] = useState<LinkItem | null>(null);
+    const reloadTimeoutRef = useRef<number | null>(null);
 
     const link_type = type === 'backlinks' ? 'Backlinks' : 'Citations';
 
-    const reloadLinks = () => {
+    const reloadLinks = useCallback(() => {
         setLoading(true);
         linkService.getLinksByType(type, project_id).then((response) => {
             setLinks(response);
             setLoading(false);
         });
-    };
+    }, [project_id, type]);
 
-    const getProjectName = () => {
+    const getProjectName = useCallback(() => {
         projectService.getProjectName(project_id).then(res => setProjectName(res) );
+    }, [project_id]);
+
+    const mergeAddedLinks = (addedLinks: LinkItem[]) => {
+        if (addedLinks.length === 0) {
+            return;
+        }
+
+        setLinks((previousLinks) => {
+            const existingIds = new Set(previousLinks.map((link) => link.id));
+            const uniqueNewLinks = addedLinks.filter((link) => !existingIds.has(link.id));
+
+            if (uniqueNewLinks.length === 0) {
+                return previousLinks;
+            }
+
+            return [...uniqueNewLinks, ...previousLinks];
+        });
     };
 
     useEffect(() => {
         reloadLinks();
         getProjectName();
-    }, [project_id]);
+    }, [getProjectName, reloadLinks]);
 
 
     // --------------------------------------------
@@ -65,14 +83,25 @@ export default function ProjectLinkPage() {
         const channel = pusher.subscribe(`backlinks.${project_id}`);
 
         channel.bind("backlink-updated", () => {
-            reloadLinks();
+            if (reloadTimeoutRef.current !== null) {
+                window.clearTimeout(reloadTimeoutRef.current);
+            }
+
+            reloadTimeoutRef.current = window.setTimeout(() => {
+                reloadLinks();
+                reloadTimeoutRef.current = null;
+            }, 500);
         });
 
         return () => {
+            if (reloadTimeoutRef.current !== null) {
+                window.clearTimeout(reloadTimeoutRef.current);
+                reloadTimeoutRef.current = null;
+            }
             channel.unbind("backlink-updated");
             pusher.unsubscribe(`backlinks.${project_id}`);
         };
-    }, [project_id]);
+    }, [project_id, reloadLinks]);
     // --------------------------------------------
 
 
@@ -106,6 +135,7 @@ export default function ProjectLinkPage() {
                 loading={loading}
                 projectId={project_id}
                 onRefresh={reloadLinks}
+                onAdded={mergeAddedLinks}
                 onDelete={(id) => {
                     setLinks(prev => prev.filter(b => b.id !== id));
                 }}

--- a/frontend/src/services/linkService.ts
+++ b/frontend/src/services/linkService.ts
@@ -41,6 +41,10 @@ export type DeleteResponseType = {
     message: string;
 }
 
+export type RecheckAllLinksResponseType = {
+    message: string;
+}
+
 export default {
     async getAll(projectId: string): Promise<LinkItem[]> {
         const res = await axios.get<LinkItem[]>(`${API}/api/projects/${projectId}/links`);
@@ -66,8 +70,8 @@ export default {
         return res.data;
     },
 
-    async reCheckAllLinks(projectId: string, type: 'backlinks' | 'citations'): Promise<void> {
-        const res = await axios.post(`${API}/api/projects/${projectId}/links/recheck-all`, {
+    async reCheckAllLinks(projectId: string, type: 'backlinks' | 'citations'): Promise<RecheckAllLinksResponseType> {
+        const res = await axios.post<RecheckAllLinksResponseType>(`${API}/api/projects/${projectId}/links/recheck-all`, {
             type
         });
         return res.data;


### PR DESCRIPTION
 
Store backlink URLs immediately and submit DataForSEO checks
in background batches instead of synchronous per-URL requests.
Update the links table optimistically after create and debounce
pusher reloads to reduce refresh storms for large imports.

Tests: add bulk backlink submission coverage for chunked queueing
and batched DataForSEO submission.
